### PR TITLE
#94 - Correct defaults for timestamps in generate_crud_model

### DIFF
--- a/modules/pulsestorm/cli/code_generation/module.php
+++ b/modules/pulsestorm/cli/code_generation/module.php
@@ -132,10 +132,7 @@ function generateInstallSchemaGetDefaultColumnTitle()
     ];
     return $title;
 }
-function timestampConstant($constant)
-{
-    return "\Magento\Framework\\DB\\Ddl\\Table::$constant";
-}
+
 function generateInstallSchemaGetDefaultColumnCreationTime()
 {
     $creation_time = [        

--- a/tests/GenerateInstallSchemaTest.php
+++ b/tests/GenerateInstallSchemaTest.php
@@ -22,39 +22,31 @@ class GenerateInstallSchemaTest extends PestleBaseTest
             \'unit_test_id\',
             \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
             null,
-            array (
-  \'identity\' => true,\'nullable\' => false,\'primary\' => true,\'unsigned\' => true,
-),
+            [ \'identity\' => true, \'nullable\' => false, \'primary\' => true, \'unsigned\' => true, ],
             \'Entity ID\'
         )->addColumn(
             \'title\',
             \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
             255,
-            array (
-  \'nullable\' => false,
-),
+            [ \'nullable\' => false, ],
             \'Demo Title\'
         )->addColumn(
             \'creation_time\',
             \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
             null,
-            array (
-),
+            [ \'nullable\' => false, \'default\' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT, ],
             \'Creation Time\'
         )->addColumn(
             \'update_time\',
             \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
             null,
-            array (
-),
+            [ \'nullable\' => false, \'default\' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT_UPDATE, ],
             \'Modification Time\'
         )->addColumn(
             \'is_active\',
             \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
             null,
-            array (
-  \'nullable\' => false,\'default\' => \'1\',
-),
+            [ \'nullable\' => false, \'default\' => \'1\', ],
             \'Is Active\'
         )->setComment(
              \'A testing table\'


### PR DESCRIPTION
One caveat is that the string munging that's unescaping the timestamp constant will only work if it's single-quoted in the column definition array. Which might be a feature if consistency is a goal (all the other column definition stuff is single-quoted too).

There's also some more whitespace diddling and array() => [] converting.
