### PR TITLE
ISSUE-119: Abstract integration test logic into base class

### DIFF
--- a/tests-integration/HelloWorldTest.php
+++ b/tests-integration/HelloWorldTest.php
@@ -1,11 +1,12 @@
-<?php 
-class FirstTest extends PHPUnit_Framework_TestCase
+<?php
+
+namespace Pulsestorm\Pestle\TestsIntegration;
+
+require_once 'PestleTestIntegration.php';
+
+class HelloWorldTest extends PestleTestIntegration
 {
-    protected function runCommand($cmd)
-    {
-        return `pestle.phar $cmd`;
-    }
-    
+
     public function testSetup()
     {
         $results = trim($this->runCommand('hello_world'));

--- a/tests-integration/PestleTestIntegration.php
+++ b/tests-integration/PestleTestIntegration.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Pulsestorm\Pestle\TestsIntegration;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+
+class PestleTestIntegration extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var string[]
+     */
+    protected $packageNames = ['pestle.phar', 'pestle', 'pestle_dev'];
+
+    /**
+     * @var $string;
+     */
+    protected $packageName;
+
+    /**
+     * Check the pestle command is available in the current environment.
+     *
+     * @test
+     */
+    public function testPestleIsAvailable()
+    {
+        $this->assertNotFalse($this->getPestlePackage());
+    }
+
+    /**
+     * Run a command from users pestle implementation.
+     *
+     * @param $cmd
+     *
+     * @return mixed
+     */
+    protected function runCommand($cmd)
+    {
+        $pestle = $this->getPestlePackage();
+        return `$pestle $cmd`;
+    }
+
+    /**
+     * Check if a package is available.
+     *
+     * @param $package
+     *
+     * @return bool
+     */
+    protected function isPackageAvailable($package) {
+        return (empty(`which $package`) ? false : true);
+    }
+
+    /**
+     * Get the correct pestle package name from the users system.
+     *
+     * @return string|bool
+     */
+    protected function getPestlePackage()
+    {
+        if(!$this->packageName === null) {
+            return $this->packageName;
+        }
+
+        $this->packageName = false;
+
+        foreach($this->packageNames as $packageName) {
+            if ($this->isPackageAvailable($packageName)) {
+                $this->packageName = $packageName;
+                break;
+            }
+        }
+
+        return $this->packageName;
+    }
+}


### PR DESCRIPTION
The unit tests have a base class in which there is a `runCommand`
method. I have created similar logic for the integration tests.

I have migrated `FirstTest.php` to `HelloWorldTest.php` as that was
the command it was testing.

Assuming we are using the pestle package in the installers environment,
I have allowed the user to name there package 3 names and added a
basic fallback structure.

**Notes:**

The point of this PR is not to add new functionality, but just to make sure the code standard and implementation is as you expected. If so I can move onto actually integrating some proper integration tests. 
