### PR TITLE
Issue 119 create module integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ build/
 pestle.phar
 build2.sh
 test.php
-/app

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 pestle.phar
 build2.sh
 test.php
+/app

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,4 +92,4 @@ script:
     - phpunit tests
     # integration tests
     - cd magento2
-    - vendor/bin/phpunit vendor/pulsestorm/pestle/tests-integration/FirstTest.php 
+    - vendor/bin/phpunit vendor/pulsestorm/pestle/tests-integration

--- a/tests-integration/GenerateModuleTest.php
+++ b/tests-integration/GenerateModuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pulsestorm\Pestle\TestsIntegration;
+
+require_once 'PestleTestIntegration.php';
+
+class GenerateModuleTest extends PestleTestIntegration
+{
+    const COMMAND = 'generate_module Pulsestore Testbed 0.0.1';
+
+    /**
+     * @var string
+     */
+    protected $result;
+
+    /**
+     * Setup the integration test.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->result = $this->runCommand();
+    }
+
+    /**
+     * Check module declaration file exists.
+     *
+     * @test
+     */
+    public function testModuleFileExists()
+    {
+        $result = file_exists(__DIR__.'/../app/code/Pulsestore/Testbed/etc/module.xml');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Check module registration file exists.
+     *
+     * @test
+     */
+    public function testRegistrationFileExists()
+    {
+        $result = file_exists(__DIR__.'/../app/code/Pulsestore/Testbed/registration.php');
+        $this->assertTrue($result);
+    }
+}

--- a/tests-integration/GenerateRouteTest.php
+++ b/tests-integration/GenerateRouteTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pulsestorm\Pestle\TestsIntegration;
+
+require_once 'PestleTestIntegration.php';
+
+class GenerateRouteTest extends PestleTestIntegration
+{
+    const COMMAND = 'generate_route Pulsestorm_HelloWorld frontend pulsestorm_helloworld';
+
+    /**
+     * @var string
+     */
+    protected $result;
+
+    /**
+     * Setup the integration test.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->runCommand(GenerateModuleTest::COMMAND);
+        $this->result = $this->runCommand();
+    }
+
+    /**
+     * Check routes declaration file exists.
+     *
+     * @test
+     */
+    public function testRoutesFileExists()
+    {
+        $result = file_exists(__DIR__.'/../app/code/Pulsestorm/HelloWorld/etc/frontend/routes.xml');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Check module registration file exists.
+     *
+     * @test
+     */
+    public function testControllerFileExists()
+    {
+        $result = file_exists(__DIR__.'/../app/code/Pulsestorm/HelloWorld/Controller/Index/Index.php');
+        $this->assertTrue($result);
+    }
+}

--- a/tests-integration/HelloWorldTest.php
+++ b/tests-integration/HelloWorldTest.php
@@ -7,9 +7,11 @@ require_once 'PestleTestIntegration.php';
 class HelloWorldTest extends PestleTestIntegration
 {
 
+    const COMMAND = 'hello_world';
+
     public function testSetup()
     {
-        $results = trim($this->runCommand('hello_world'));
-        $this->assertEquals($results,'Hello Sailor');
+        $results = trim($this->runCommand());
+        $this->assertEquals($results, 'Hello Sailor');
     }
 }

--- a/tests-integration/PestleTestIntegration.php
+++ b/tests-integration/PestleTestIntegration.php
@@ -20,6 +20,8 @@ class PestleTestIntegration extends PHPUnit_Framework_TestCase
      */
     protected $packageName;
 
+    protected $removeApp = false;
+
     /**
      * Setup the integration tests.
      */
@@ -27,7 +29,10 @@ class PestleTestIntegration extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->createFakeMagentoInstance();
+        if (!file_exists('app')) {
+            $this->createFakeMagentoInstance();
+            $this->removeApp = true;
+        }
     }
 
     /**
@@ -37,7 +42,9 @@ class PestleTestIntegration extends PHPUnit_Framework_TestCase
     {
         parent::tearDown();
 
-        $this->deleteDirectoryTree('app');
+        if ($this->removeApp) {
+            $this->deleteDirectoryTree('app');
+        }
     }
 
     /**
@@ -78,6 +85,17 @@ class PestleTestIntegration extends PHPUnit_Framework_TestCase
     public function testPestleIsAvailable()
     {
         $this->assertNotFalse($this->getPestlePackage());
+    }
+
+    /**
+     * Check the di.xml exists, if it does not then something is
+     * wrong with the install.
+     *
+     * @test
+     */
+    public function testDiXmlExists()
+    {
+        $this->assertFileExists('app/etc/di.xml');
     }
 
     /**

--- a/tests-integration/PestleTestIntegration.php
+++ b/tests-integration/PestleTestIntegration.php
@@ -8,6 +8,8 @@ use PHPUnit_Framework_TestCase;
 class PestleTestIntegration extends PHPUnit_Framework_TestCase
 {
 
+    const COMMAND = '';
+
     /**
      * @var string[]
      */
@@ -17,6 +19,56 @@ class PestleTestIntegration extends PHPUnit_Framework_TestCase
      * @var $string;
      */
     protected $packageName;
+
+    /**
+     * Setup the integration tests.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->createFakeMagentoInstance();
+    }
+
+    /**
+     * Tear down the integration tests.
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->deleteDirectoryTree('app');
+    }
+
+    /**
+     * Create `app/etc/di.xml` so pestle.phar can work.
+     *
+     * @return $this
+     */
+    protected function createFakeMagentoInstance()
+    {
+        mkdir('app');
+        mkdir('app/etc');
+        touch('app/etc/di.xml');
+
+        return $this;
+    }
+
+    /**
+     * Delete a directory tree: http://php.net/manual/en/function.rmdir.php
+     *
+     * @param $directory
+     *
+     * @return bool
+     */
+    protected function deleteDirectoryTree($directory) {
+        $files = array_diff(scandir($directory), array('.','..'));
+        foreach ($files as $file) {
+            (is_dir("$directory/$file")) ? $this->deleteDirectoryTree("$directory/$file") : unlink("$directory/$file");
+        }
+
+        return rmdir($directory);
+    }
 
     /**
      * Check the pestle command is available in the current environment.
@@ -35,8 +87,12 @@ class PestleTestIntegration extends PHPUnit_Framework_TestCase
      *
      * @return mixed
      */
-    protected function runCommand($cmd)
+    protected function runCommand($cmd = false)
     {
+        if (!$cmd) {
+            $cmd = static::COMMAND;
+        }
+
         $pestle = $this->getPestlePackage();
         return `$pestle $cmd`;
     }


### PR DESCRIPTION
Hi @astorm,

I have only updated `travis.yml`, I think I can see the issue. Have you setup Travis on OS x? I had a brief look on their website and couldn't see if I could setup the build locally.

I have also added some new integration tests, if the directory `app` doesn't exist I create a fake `app/etc/di.xml` so the tests can run, on tear down I remove it.

I will expand on these tests if you're happy with the architecture. 
