### PR TITLE
make build.sh more portable by ensuring phar.readonly=0 for every run

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-vendor/bin/phing package_phar
+php -d phar.readonly=0 vendor/bin/phing package_phar
 chmod +x pestle.phar
 #mv pestle.phar ~/bin/pestle.phar


### PR DESCRIPTION
This PR ensures that build.sh doesn't get tripped up if a user's php uses `phar.readonly = On`.

For instance, on my system I'm using homebrew-php which has the following phar php.ini settings:

```
$ php -i | grep phar
Registered PHP Streams => https, ftps, compress.zlib, compress.bzip2, php, file, glob, data, http, ftp, phar, zip
Phar-based phar archives => enabled
Tar-based phar archives => enabled
ZIP-based phar archives => enabled
phar.cache_list => no value => no value
phar.readonly => On => On
phar.require_hash => On => On
```
