### PR TITLE
#123: Updated runner.php to check php version before executing commands.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "pulsestorm/pestle",
 
     "require": {
+        "php": ">=5.6.0",
         "michelf/php-markdown": "1.6.0"
     },
     

--- a/runner.php
+++ b/runner.php
@@ -4,4 +4,23 @@ function main($argv)
     include 'modules/pulsestorm/pestle/runner/module.php';
     \Pulsestorm\Pestle\Runner\main($argv);
 }
-main($argv);
+
+function phpVersionCheck($argv) {
+    $passedVersionCheck = true;
+
+    $composerJson = json_decode(file_get_contents("composer.json"), true);
+    if(array_key_exists("require", $composerJson) && array_key_exists("php", $composerJson["require"])) {
+        $minimumPhpVersion = str_replace(">=", "", $composerJson["require"]["php"]);
+        $currentPhpVersion = phpversion();
+
+        if($currentPhpVersion < $minimumPhpVersion) {
+            $passedVersionCheck = false;
+            echo("Error: You must be running PHP version ". $minimumPhpVersion . " or later to use Pestle.");
+        }
+    }
+
+    if($passedVersionCheck) {
+        main($argv);
+    }
+}
+phpVersionCheck($argv);


### PR DESCRIPTION
This will break if the version notation on composer.json > require > php ever changes to support version logic other than greater than, but that seems unlikely. 
