### PR TITLE
Update function generateUiComponentXmlFile

### DIFF
--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/grid/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/grid/module.php
@@ -168,10 +168,10 @@ function generateUiComponentXmlFile($gridId, $databaseIdName, $module_info, $col
 
     $xml             = simplexml_load_string(getBlankXml('uigrid'));        
     $argument        = generateArgumentNode($xml, $gridId, $dataSourceName, $columnsName, $collection);        
-    $dataSource      = generateDatasourceNode($xml, $dataSourceName, $providerClass, $databaseIdName, $requestIdName);    
+    $dataSource      = generateDatasourceNode($xml, $dataSourceName, $providerClass, $databaseIdName, $requestIdName);
+    generateListingToolbar($xml);
     $columns         = generateColumnsNode($xml, $columnsName, $databaseIdName, $pageActionsClassName);
-    generateListingToolbar($xml);   
-    
+     
     $path = $module_info->folder . 
         '/view/adminhtml/ui_component/' . $gridId . '.xml';        
     output("Creating New $path");


### PR DESCRIPTION
Result of generateListingToolbar needs to be added after result of generateDatasourceNode and before result of generateColumnsNode inside xml. Otherwise our `listing_top` ends up on the bottom of the grid. CE 2.1.3

For eg. `<listingToolbar name="listing_top">` is added right after `</dataSource>` element in `../module-catalog/view/adminhtml/ui_component/product_listing.xml`