### PR TITLE
Let pestle_dev be independent of current directory

### DIFF
--- a/pestle_dev
+++ b/pestle_dev
@@ -1,3 +1,3 @@
 #!/usr/bin/env php
 <?php
-require_once('./runner.php');
+require_once(__DIR__ . '/runner.php');


### PR DESCRIPTION
make pestle_dev runnable from dirs other than current.

I always find myself trying to invoke it from /path/to/magento2