### PR TITLE
Refactor UI Form Component Data Provider

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 VER_FROM_TAG=`git tag | tail -n 1 | xargs echo 'pestle Ver'`
-VER_FROM_PESTLE=`pestle_dev version`
+VER_FROM_PESTLE=`php pestle_dev version`
 
 if [ "$VER_FROM_TAG" != "$VER_FROM_PESTLE" ]
 then

--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
@@ -254,6 +254,10 @@ function createDataProviderUseString($module_info, $modelClass)
     $collectionClassName = createCollectionClassNameFromModelName($modelClass);
         
     return 'use '.$collectionClassName.';
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\Search\ReportingInterface;
+use Magento\Framework\Api\Search\SearchCriteriaBuilder;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Request\DataPersistorInterface;';
 }
 
@@ -275,9 +279,14 @@ function createDataProviderClassBodyString($module_info, $modelClass)
     protected $loadedData;
 
     /**
+     * DataProvider constructor.
      * @param string $name
      * @param string $primaryFieldName
      * @param string $requestFieldName
+     * @param ReportingInterface $reporting
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param RequestInterface $request
+     * @param FilterBuilder $filterBuilder
      * @param CollectionFactory $collectionFactory
      * @param DataPersistorInterface $dataPersistor
      * @param array $meta
@@ -287,6 +296,10 @@ function createDataProviderClassBodyString($module_info, $modelClass)
         $name,
         $primaryFieldName,
         $requestFieldName,
+        ReportingInterface $reporting,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        RequestInterface $request,
+        FilterBuilder $filterBuilder,
         CollectionFactory $collectionFactory,
         DataPersistorInterface $dataPersistor,
         array $meta = [],
@@ -294,7 +307,7 @@ function createDataProviderClassBodyString($module_info, $modelClass)
     ) {
         $this->collection = $collectionFactory->create();
         $this->dataPersistor = $dataPersistor;
-        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $reporting,$searchCriteriaBuilder, $request, $filterBuilder, $meta, $data);
         $this->meta = $this->prepareMeta($this->meta);
     }
 
@@ -357,7 +370,7 @@ function createDataProvider($module_info, $modelClass)
     $dataProviderClassName = createDataProviderClassNameFromModelClassName($modelClass);
     $contents           = createClassWithUse(
         $dataProviderClassName, 
-        '\Magento\Ui\DataProvider\AbstractDataProvider',
+        '\Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider',
         createDataProviderUseString($module_info, $modelClass),
         createDataProviderClassBodyString($module_info, $modelClass)        
     );        


### PR DESCRIPTION
- Adjust which class the UI Form Component Data Provider extends. 
- Build.sh assumes that pestle_dev is executable

The names for the layout files generated for each controller action assume that the `frontname` for the route will be the namespace_modulename. Perhaps a prompt can be added for the `frontname` and that can be used to choose the file name.