### PR TITLE
Build.sh assumes that pestle_dev is executable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 VER_FROM_TAG=`git tag | tail -n 1 | xargs echo 'pestle Ver'`
-VER_FROM_PESTLE=`pestle_dev version`
+VER_FROM_PESTLE=`php pestle_dev version`
 
 if [ "$VER_FROM_TAG" != "$VER_FROM_PESTLE" ]
 then


### PR DESCRIPTION
Correct a potential issue in the build process depending on the environment setup.