### PR TITLE
Fix auto-complete bug

### DIFF
--- a/pestle-autocomplete.sh
+++ b/pestle-autocomplete.sh
@@ -407,6 +407,7 @@ _pestleAutocomplete ()
         (( counter++ ))
     done
 
+    command=$(echo "$command" | sed 's/\\//g')
     if [ "$command" == "magento2:generate:observer" ] ; then
         let command_input=cword-command_pos
         #the event input is the 2nd option passed to magento2:generate:observer

--- a/pestle-autocomplete.sh
+++ b/pestle-autocomplete.sh
@@ -385,8 +385,7 @@ _observer_list(){
 
 _pestleAutocomplete ()
 {
-    local cur
-    local all
+    local all cur prev words cword command command_input
     _get_comp_words_by_ref -n : cur prev words cword
 
     local counter=1


### PR DESCRIPTION
### Fix a bug where `command` variable wasn't being cleared ###

The bug is after command is assigned the value `magento2:generate:observer` trying to invoke pestle again with no command and triggering auto-completion will not bring up the command list suggestions

### Ignore colon escapes when doing autocompletion ###

The `\` characters added by tab completion for colons makes inspection of the variable $command meaningless. We get rid of the `\` here.

Another fix might be to get rid of colon escaping all together but I'm not sure what effect this will have on other kind of shells other than bash