### PR TITLE
A command that outputs the magento2 base directory

### DIFF
--- a/modules/pulsestorm/magento2/cli/base_directory/module.php
+++ b/modules/pulsestorm/magento2/cli/base_directory/module.php
@@ -1,0 +1,16 @@
+<?php
+namespace Pulsestorm\Magento2\Cli\Base_Directory;
+use function Pulsestorm\Pestle\Importer\pestle_import;
+pestle_import('Pulsestorm\Pestle\Library\output');
+pestle_import('Pulsestorm\Magento2\Cli\Library\getBaseMagentoDir');
+pestle_import('Pulsestorm\Pestle\Library\exitWithErrorMessage');
+
+/**
+* Output the base magento2 directory
+*
+* @command magento2:base-dir
+*/
+function pestle_cli($argv)
+{
+    output(getBaseMagentoDir());
+}


### PR DESCRIPTION
I need this to cook up module names autocompletion

As a side note I had a bit of a struggle with `pestle:generate-command` I don't understand how it generates the name space and the directory structure given the command name and the name space