### PR TITLE
Command arguement type detection and module name auto completion

### DIFF
--- a/modules/pulsestorm/magento2/cli/base_directory/module.php
+++ b/modules/pulsestorm/magento2/cli/base_directory/module.php
@@ -1,0 +1,16 @@
+<?php
+namespace Pulsestorm\Magento2\Cli\Base_Directory;
+use function Pulsestorm\Pestle\Importer\pestle_import;
+pestle_import('Pulsestorm\Pestle\Library\output');
+pestle_import('Pulsestorm\Magento2\Cli\Library\getBaseMagentoDir');
+pestle_import('Pulsestorm\Pestle\Library\exitWithErrorMessage');
+
+/**
+* Output the base magento2 directory
+*
+* @command magento2:base-dir
+*/
+function pestle_cli($argv)
+{
+    output(getBaseMagentoDir());
+}

--- a/modules/pulsestorm/magento2/cli/help/module.php
+++ b/modules/pulsestorm/magento2/cli/help/module.php
@@ -4,14 +4,15 @@ use function Pulsestorm\Pestle\Importer\pestle_import;
 pestle_import('Pulsestorm\Pestle\Runner\applyCommandNameAlias');
 /**
 * Alias for list
+* @option is-machine-readable pipable/processable output?
 * @command help
 */
-function pestle_cli($argv)
+function pestle_cli($argv, $options)
 {
     require_once __DIR__ . '/../list_commands/module.php';
     if(isset($argv[0]))
     {
         $argv[0] = applyCommandNameAlias($argv[0]);
     }
-    return \Pulsestorm\Magento2\Cli\List_Commands\pestle_cli($argv);
+    return \Pulsestorm\Magento2\Cli\List_Commands\pestle_cli($argv, $options);
 }

--- a/modules/pulsestorm/magento2/cli/list_commands/module.php
+++ b/modules/pulsestorm/magento2/cli/list_commands/module.php
@@ -6,14 +6,16 @@ pestle_import('Pulsestorm\Pestle\Library\getAtCommandFromDocComment');
 pestle_import('Pulsestorm\Pestle\Library\getDocCommentAsString');
 pestle_import('Pulsestorm\Pestle\Library\output');
 pestle_import('Pulsestorm\Cli\Build_Command_List\includeAllModuleFiles');
+pestle_import('Pulsestorm\Pestle\Runner\commandNameToDocBlockParts');
 /**
 * Lists help
 * Read the doc blocks for all commands, and then
 * outputs a list of commands along with thier doc
 * blocks.  
+* @option is-machine-readable pipable/processable output?
 * @command list-commands
 */
-function pestle_cli($argv)
+function pestle_cli($argv, $options)
 {
     includeAllModuleFiles();
     
@@ -45,6 +47,15 @@ function pestle_cli($argv)
                 $s['command'] === str_replace('_','-',$command_to_check);
         });
     }
+
+    if(array_key_exists('is-machine-readable', $options)){
+        $docBlockAndCommand = commandNameToDocBlockParts($command_to_check);
+        foreach ($docBlockAndCommand['docBlockParts']['argument'] as $argument){
+            output(getAtArguementType($argument));
+        }
+        return;
+    }
+
     output('');
     
     if(count($commands) > 1)
@@ -73,6 +84,19 @@ function pestle_cli($argv)
         output('');
         output('');
     }
+}
+
+function getAtArguementType($arguement){
+    preg_match('/^[a-zA-Z0-9_]+/', $arguement, $matches);
+    if(count($matches) < 1){
+        return '';
+    }
+
+    if(count($matches) > 1){
+        throw new Exception('Multiple types found for arguement');
+    }
+
+    return $matches[0];
 }
 
 function getWhitespaceForCommandList($commands, $command_name)

--- a/modules/pulsestorm/magento2/cli/list_commands/module.php
+++ b/modules/pulsestorm/magento2/cli/list_commands/module.php
@@ -48,7 +48,7 @@ function pestle_cli($argv, $options)
         });
     }
 
-    if(array_key_exists('is-machine-readable', $options)){
+    if(array_key_exists('is-machine-readable', $options) && !is_null($options['is-machine-readable'])){
         $docBlockAndCommand = commandNameToDocBlockParts($command_to_check);
         foreach ($docBlockAndCommand['docBlockParts']['argument'] as $argument){
             output(getAtArguementType($argument));

--- a/modules/pulsestorm/pestle/runner/module.php
+++ b/modules/pulsestorm/pestle/runner/module.php
@@ -368,6 +368,16 @@ function bootstrapPhp()
     error_reporting(E_ALL);
 }
 
+function commandNameToDocBlockParts($command_name){
+    //include in the library for this command
+    includeLibraryForCommand($command_name);   
+    $command = getReflectedCommand($command_name);
+    return [ 
+        'docBlockParts' => parseDocBlockIntoParts($command->getDocComment()), 
+        'command' => $command
+    ];
+}
+
 /**
 * Main entry point
 */
@@ -386,13 +396,10 @@ function main($argv)
         $command_name               = 'pestle_run_file';        
         $parsed_argv['command']     = $command_name;        
     }        
-    //include in the library for this command
-    includeLibraryForCommand($command_name);            
-    $command        = getReflectedCommand($command_name);
-    $doc_block      = parseDocBlockIntoParts($command->getDocComment());
+    $docBlockAndCommand      = commandNameToDocBlockParts($command_name);
 
     list($arguments, $options) = 
-        getArgumentsAndOptionsFromParsedArgvAndDocComment($parsed_argv, $doc_block, $command);
+        getArgumentsAndOptionsFromParsedArgvAndDocComment($parsed_argv, $docBlockAndCommand['docBlockParts'], $docBlockAndCommand['command']);
     
-    $command->invokeArgs([$arguments, $options]);
+    $docBlockAndCommand['command']->invokeArgs([$arguments, $options]);
 }

--- a/pestle-autocomplete.sh
+++ b/pestle-autocomplete.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 # 'globals' within bash context
+# used for caching purposes to avoid calling
+# pestle unless we have to
 pestle_magento2_base_directory=""
 pestle_module_suggestions=""
-have_suggestions_for=""
+pestle_have_suggestions_for=""
 pestle_arg_types_suggestions=""
-currently_suggesting=""
+pestle_currently_suggesting=""
 
 _commandList ()
 {
@@ -407,17 +409,17 @@ _pestleBootStrapCommandArgTypes () {
 _getArgTypeToSuggestFor (){
     local command_input
 
-    #have_suggestions_for and pestle_arg_types_suggestions are global
+    #pestle_have_suggestions_for and pestle_arg_types_suggestions are global
     #need this to decide whether we need to rebootstrap pestle or not
     #because running pestle is laggy and not ideal on every tab hit
-    if [[ "'$have_suggestions_for'" != "'$2'" ]]; then 
+    if [[ "'$pestle_have_suggestions_for'" != "'$2'" ]]; then 
         pestle_arg_types_suggestions=( $(_pestleBootStrapCommandArgTypes $1 $2) )
     fi
-    have_suggestions_for="$2"
+    pestle_have_suggestions_for="$2"
 
     let command_input=$3-$4
     let command_input=$command_input-1
-    currently_suggesting=${pestle_arg_types_suggestions[$command_input]}
+    pestle_currently_suggesting=${pestle_arg_types_suggestions[$command_input]}
 }
 
 #obtain the magento2_base_directory and cache it
@@ -466,12 +468,12 @@ _pestleAutocomplete ()
         _getArgTypeToSuggestFor $1 $command $cword $command_pos
         #TODO: fix this type inconsistency in commands (example: generate:observer vs generate:command)
         #one takes one the other takes the other
-        if [[ "$currently_suggesting" == "module" ]] || [[ "$currently_suggesting" == "module" ]]; then
+        if [[ "$pestle_currently_suggesting" == "module" ]] || [[ "$pestle_currently_suggesting" == "module_name" ]]; then
             _generateModuleSuggestions $1
             all=$pestle_module_suggestions
         fi
         if [ "$command" == "magento2:generate:observer" ] ; then
-            if [ "$currently_suggesting" == "event_name" ] ; then
+            if [ "$pestle_currently_suggesting" == "event_name" ] ; then
                 all=$(_observer_list)
             fi
         fi

--- a/pestle-autocomplete.sh
+++ b/pestle-autocomplete.sh
@@ -2,6 +2,7 @@
 
 _commandList ()
 {
+    echo "magento2:base-dir"
     echo "codecept:convert-selenium-id-for-codecept"
     echo "magento2:check-templates"
     echo "magento2:class-from-path"


### PR DESCRIPTION
## Proposed Changes ##

1. Implement a function that calls pestle to establish the current `arguement type` to suggest for
    a. Scans command's docBlock for types
    b. `list-command` returns bash-parsable output with new option `--is-machine-readable`
    c. New option propogated to the aliasing command `help`
    d. Caches the result for subsequent invocations.
    e. Opens door to other enthusiasts to implement completion for other `arguement type`s
    f. Use function to update detection logic for observer suggestion

2. Implement a command that prints the magento2 base directory by calling `pestle`'s equivalent if available
    a. Caches the result for subsequent invocations

3. Use 1. and 2. to Implement module name auto completion as a start.

## Room for improvement ##

Need means to invalidate cache variables. 
Need better error reporting on failure (what happens when we attempt to autocomplete when `magento2:base-dir` command fails?)

## How to Improve ##

for 1. we can listen for changes on all the `app/code/<Vendor>/<Module>` directories and reinvoke `_generateModuleSuggestions` on changes
for 2. we can track the current working directory and see if it's contained within the initially returned working directory. If not we call `_getMagentoRootDirectory` to refresh the value