### PR TITLE
Class list command and auto complete

### DIFF
--- a/modules/pulsestorm/magento2/cli/class_list/module.php
+++ b/modules/pulsestorm/magento2/cli/class_list/module.php
@@ -1,0 +1,161 @@
+<?php
+namespace Pulsestorm\Magento2\Cli\ClassList;
+use function Pulsestorm\Pestle\Importer\pestle_import;
+
+pestle_import('Pulsestorm\Pestle\Library\output');
+pestle_import('Pulsestorm\Pestle\Library\exitWithErrorMessage');
+pestle_import('Pulsestorm\Magento2\Cli\Library\getBaseMagentoDir');
+
+/*
+ * TODO: move functions someplace more appropriate
+ */
+/**
+ * Build list of magento module path regexps which should be excluded from compilation
+ *
+ * @param string[] $modulePaths
+ * @return string[]
+ */
+function getMagentoExcludedModulePaths(array $modulePaths)
+{
+    $modulesByBasePath = [];
+    foreach ($modulePaths as $modulePath) {
+        $moduleDir = basename($modulePath);
+        $vendorPath = dirname($modulePath);
+        $vendorDir = basename($vendorPath);
+        $basePath = dirname($vendorPath);
+        $modulesByBasePath[$basePath][$vendorDir][] = $moduleDir;
+    }
+
+    $basePathsRegExps = [];
+    foreach ($modulesByBasePath as $basePath => $vendorPaths) {
+        $vendorPathsRegExps = [];
+        foreach ($vendorPaths as $vendorDir => $vendorModules) {
+            $vendorPathsRegExps[] = $vendorDir
+                . '/(?:' . join('|', $vendorModules) . ')';
+        }
+        $basePathsRegExps[] = $basePath
+            . '/(?:' . join('|', $vendorPathsRegExps) . ')';
+    }
+
+    $excludedModulePaths = [
+        '#^(?:' . join('|', $basePathsRegExps) . ')/Test#',
+    ];
+    return $excludedModulePaths;
+}
+
+/**
+ * Build list of magento library path regexps which should be excluded from compilation
+ *
+ * @param string[] $libraryPaths
+ * @return string[]
+ */
+function getMagentoExcludedLibraryPaths(array $libraryPaths)
+{
+    $excludedLibraryPaths = [
+        '#^(?:' . join('|', $libraryPaths) . ')/([\\w]+/)?Test#',
+    ];
+    return $excludedLibraryPaths;
+}
+
+/**
+ * @param \Magento\Framework\ObjectManagerInterface $objectManager
+ * @return string[]
+ */
+function getMagentoExtendableClassList($objectManager){
+    $componentRegistrarClass = $objectManager->get('Magento\Framework\Component\ComponentRegistrar');
+    $classScanner = $objectManager->get('Magento\Setup\Module\Di\Code\Reader\ClassesScanner');
+
+    $modulePaths = $componentRegistrarClass->getPaths(\Magento\Framework\Component\ComponentRegistrar::MODULE);
+    $libraryPaths = $componentRegistrarClass->getPaths(\Magento\Framework\Component\ComponentRegistrar::LIBRARY);
+    //TODO: add this in the future
+    //$generationPath = $this->directoryList->getPath(DirectoryList::GENERATION);
+
+    $classScanner->addExcludePatterns([
+        'application' => getMagentoExcludedModulePaths($modulePaths),
+        'framework' => getMagentoExcludedLibraryPaths($libraryPaths),
+    ]);
+
+    // TODO: add generation path
+    $paths = array_merge($modulePaths, $libraryPaths);
+
+    $classList = [];
+    foreach ($paths as $path){
+        $classList = array_merge($classList, $classScanner->getList($path));
+    }
+
+    return $classList;
+}
+
+/**
+ * Unregister an array of callable autoloaders
+ *
+ * @param callable[] $callables array of callables to unregister
+ * @return callable[] the array of unregistered autoloaders
+ */
+function unregisterAutoloaders($callables){
+    foreach ($callables as $callable) {
+        spl_autoload_unregister($callable);
+    }
+    return $callables;
+}
+
+/**
+ * Unregister all active autoloaders
+ *
+ * @return callable[] the array of unregistered autoloaders
+ */
+function unregisterAllAutoloaders(){
+    return unregisterAutoloaders(spl_autoload_functions());
+}
+
+/**
+ * Register an array of callable autoloaders
+ *
+ * @param callable[] $callables array of callables to register
+ * @return callable[] the array of all registered autoloaders
+ */
+function registerAutoloaders($callables){
+    foreach ($callables as $callable) {
+        spl_autoload_register($callable);
+    }
+    return spl_autoload_functions();
+}
+
+/**
+* Get a list of all of magento2's extensible classes
+*
+* @command magento2:class-list
+*/
+function pestle_cli($argv)
+{
+
+    $pestlesLoaders = unregisterAllAutoloaders();
+    try {
+        /*
+         * Place magento's autoloaders higher up the queue over pestle's
+         * TODO: the 'save/reorder loaders -> run blackbox -> restore' pattern can be templated
+         */
+        // Magento's autoloaders are loaded here
+        require getBaseMagentoDir() . '/app/bootstrap.php';
+
+        registerAutoloaders($pestlesLoaders);
+        /*
+         * TODO: wrap this logic in an application container
+         * create application, and run it.
+         * Will allow us to properly use magento2's EXTREMELY powerful constructor di.
+         */
+        $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+        $objManager = $bootstrap->getObjectManager();
+        $magentoClassList = getMagentoExtendableClassList($objManager);
+        foreach ($magentoClassList as $item) {
+            output($item);
+        }
+    } catch (\Exception $e) {
+        output('Magento2 autoload/bootstrap/application creation/run error');
+    } finally {
+        // keep only pestle's loaders
+        unregisterAutoloaders(spl_autoload_functions());
+        registerAutoloaders($pestlesLoaders);
+    }
+}
+

--- a/pestle-autocomplete.sh
+++ b/pestle-autocomplete.sh
@@ -8,6 +8,7 @@ pestle_module_suggestions=""
 pestle_have_suggestions_for=""
 pestle_arg_types_suggestions=""
 pestle_currently_suggesting=""
+pestle_pluggable_class_suggestions=""
 
 _commandList ()
 {
@@ -454,6 +455,12 @@ _generateModuleSuggestions (){
     fi
 }
 
+_generatePluggableClassSuggestions (){
+    if [[ "$pestle_pluggable_class_suggestions" == "" ]] && _haveMagentoRootDirectory; then
+        pestle_pluggable_class_suggestions="$($1 magento2:class-list | sed 's/\\/\\\\/g')"
+    fi
+}
+
 _pestleAutocomplete ()
 {
     local all cur prev words cword command command_input suggesting_a
@@ -488,6 +495,13 @@ _pestleAutocomplete ()
             _generateModuleSuggestions $1
             all=$pestle_module_suggestions
         fi
+
+        if [[ "$pestle_currently_suggesting" == "class" ]] ; then
+            _getMagentoRootDirectory $1
+            _generatePluggableClassSuggestions $1
+            all=$pestle_pluggable_class_suggestions
+        fi
+
         if [ "$command" == "magento2:generate:observer" ] ; then
             if [ "$pestle_currently_suggesting" == "event_name" ] ; then
                 all=$(_observer_list)
@@ -497,7 +511,7 @@ _pestleAutocomplete ()
         all=$(_commandList)
     fi
 
-    COMPREPLY=( $(compgen -W "$all" $cur) )
+    COMPREPLY=( $(compgen -W "$all" $cur | sed 's/\\/\\\\/g' ) )
     __ltrim_colon_completions "$cur"
     return 0
 }


### PR DESCRIPTION
## class-list command
`magento2:class-list`
Added a new class list command that scans magento2 for pluggable classes. It uses the same approach as the magento `setup:di:compile` command.

## auto complete for type `class`
The command is used to auto complete the arguement type `class`, one such command that uses this type is `magento2:generate:plugin-xml`

The class list command takes a bit to run, but the auto complete script caches the result so that it only has to run once

It might be more fitting to 'warm-up' the cache when `pestle-autocomplete.sh` is sourced within a magento root.

## Room for improvement
See the TODOs

The code for extracting the module/library directories can be factored out

Utility functions can be factored out into appropriate places (such as the ones that save/restore autoloaders)

One major improvement that can be done is extracting magento2's bootstrapping into its own static class, and then using that as a basis of utility functions

## Still not sure
I'm overall still unsure of how pestle's new module system plays with autoloading, but I tried to be defensive where I could 