### PR TITLE
Beta support for loading modules from other folders.

### DIFF
--- a/modules/pulsestorm/cli/build_command_list/module.php
+++ b/modules/pulsestorm/cli/build_command_list/module.php
@@ -2,6 +2,7 @@
 namespace Pulsestorm\Cli\Build_Command_List;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
+use AppendIterator;
 use ReflectionFunction;
 use function Pulsestorm\Pestle\Importer\pestle_import;
 pestle_import('Pulsestorm\Pestle\Library\output');
@@ -9,15 +10,21 @@ pestle_import('Pulsestorm\Pestle\Library\getDocCommentAsString');
 pestle_import('Pulsestorm\Pestle\Importer\getCacheDir');
 pestle_import('Pulsestorm\Pestle\Runner\getBaseProjectDir');
 pestle_import('Pulsestorm\Pestle\Library\parseDocBlockIntoParts');
+pestle_import('Pulsestorm\Pestle\Importer\getModuleFolders');
 
 function getListOfFilesInModuleFolder()
 {
-    $path = getBaseProjectDir() . '/modules/';
-    $objects = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($path), 
-        RecursiveIteratorIterator::SELF_FIRST
-    );
-    return $objects;
+    $iterator = new AppendIterator();    
+    foreach(getModuleFolders() as $path)
+    {
+        $objects = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path), 
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        $iterator->append($objects);
+    }    
+    return $iterator;
+    // return $objects;
 }
 
 function includeAllModuleFiles()

--- a/modules/pulsestorm/pestle/importer/module.php
+++ b/modules/pulsestorm/pestle/importer/module.php
@@ -46,6 +46,18 @@ function extractFunctionNameAndNamespace($full)
     ];
 }
 
+function getModuleFolders()
+{
+    $paths = [getBaseProjectDir() . '/modules/'];    
+    $home = trim(`echo ~`);
+    $pathConfig = $home . '/.pestle/module-folders.json';    
+    if(is_dir($home) && file_exists($pathConfig) && $config = json_decode(file_get_contents($pathConfig)))
+    {
+        $paths = array_merge($paths, $config->{'module-folders'});
+    }
+    return $paths;
+}
+
 function getPathFromFunctionName($function_name)
 {
     $function_name = strToLower($function_name);
@@ -53,7 +65,19 @@ function getPathFromFunctionName($function_name)
     $short_name    = array_pop($parts);
     $namespace     = implode('/',$parts);
     $file          = $namespace . '/module.php';
-    return getBaseProjectDir() . '/modules/' . $file;
+    
+    $folders = getModuleFolders();
+    foreach($folders as $folder)
+    {
+        $fullPath = $folder . '/' . $file;
+        if(file_exists($fullPath))
+        {
+            return $fullPath;
+        }
+    }
+    
+    exit("Could not find $file in any folder.\n");
+    // return getBaseProjectDir() . '/modules/' . $file;
 }
 
 function includeModule($function_name)


### PR DESCRIPTION
Allows a user to create a `~/.pestle/module-folders.json` file

    {
        "module-folders":[
            "/path/to/modules"
        ]
    }

and pestle will look for modules in these additional folders.  Beta support right now -- not even sure if this will play nice with the built `.phar` file. 