### PR TITLE
Remove useless use Model\Page

### DIFF
--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
@@ -203,7 +203,6 @@ function createControllerFiles($module_info, $modelClass, $aclRule)
         {
             $useString = '
 use Magento\Backend\App\Action;
-use '.$prefix.'\Model\Page;
 use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Exception\LocalizedException;
             ';


### PR DESCRIPTION
Hello,

A `use` statement is added on every save controller and try to add our module `Model\Page` but this class does not exist, I think it's an oversight.