### PR TITLE
Fix settings error in ui component

### DIFF
--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/grid/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/grid/module.php
@@ -124,7 +124,7 @@ function generateListingToolbar($xml)
     $listingToolbar = $xml->addChild('listingToolbar');
     $listingToolbar->addAttribute('name', 'listing_top');
 
-    $settings = $xml->addChild('settings');
+    $settings = $listingToolbar->addChild('settings');
     $settings->addChild('sticky', 'true');
 
     $paging = $listingToolbar->addChild('paging');


### PR DESCRIPTION
Hi,

The PR #331 has caused an error because the `setting` tag in file `view/adminhtml/ui_component/module_model.xml` is not at the right position.