### PR TITLE
#273 Generated code is not PSR-2 compliant [WIP]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
         "phing/phing": "2.*",
-        "phpspec/prophecy":"1.7.0"                
+        "phpspec/prophecy":"1.7.0",
+        "squizlabs/php_codesniffer": "^3.2"                
     },
     "autoload": {
         "files": ["library/autoload.php"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7e992f30f75f6df9ac92aad130d4a36",
+    "content-hash": "4e3ebe85570b39fbc84f7f66461c63f3",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1935,6 +1935,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/modules/pulsestorm/cli/code_generation/module.php
+++ b/modules/pulsestorm/cli/code_generation/module.php
@@ -215,7 +215,7 @@ function templateRegistrationPhp($module_name, $type='MODULE')
         \Magento\Framework\Component\ComponentRegistrar::'.$type.',
         \''.$module_name.'\',
         __DIR__
-    );';
+    );' . "\n";
 }
 
 function createBasicClassContents($full_model_name, $method_name, $extends=false)
@@ -224,7 +224,7 @@ function createBasicClassContents($full_model_name, $method_name, $extends=false
     $name = array_pop($parts);
     $namespace = implode('\\', $parts);
     $contents =  '<' . '?' . 'php' . "\n";
-    $contents .= 'namespace ' . $namespace . ";\n";
+    $contents .= 'namespace ' . $namespace . ";\n\n";
     $contents .= 'class ' . $name ;
     $contents .= "\n" . '{' . "\n";
     $contents .= '    public function ' . $method_name . '($parameters)' . "\n";
@@ -242,13 +242,13 @@ function templateInterface($interface, $functions=[])
     $name       = array_pop($parts);
     $template   = '<' . '?' . 'php' . "\n" .
     'namespace ' . implode('\\',$parts) . ";\n" .
-    "interface $name \n{\n";
+    "\ninterface $name\n{\n";
     foreach($functions as $function)
     {
         $template .=
 '    function '.$function.'();' . "\n";
     }
-    $template   .= "}";
+    $template   .= "}\n";
 
     return $template;
 }
@@ -277,7 +277,7 @@ function createClassTemplate($class, $extends=false, $implements=false, $include
     $name  = array_pop($parts);
 
     $template = '<' . '?' . 'php' . "\n" .
-    'namespace ' . implode('\\',$parts) . ";\n";
+    'namespace ' . implode('\\',$parts) . ";\n\n";
     if($includeUse)
     {
         $template .= '<$use$>' . "\n";
@@ -289,7 +289,7 @@ function createClassTemplate($class, $extends=false, $implements=false, $include
     }
     if($implements)
     {
-        $template .= " implements $implements";
+        $template .= " implements\n    $implements";
     }
     $template .= "\n" .
     '{' . '<$body$>' . '}' . "\n";
@@ -336,8 +336,8 @@ function createControllerClass($class, $area, $acl='ACL RULE HERE')
     protected $resultPageFactory;
     public function __construct(
         ' . $context_hint . ' $context,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory)
-    {
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+    ) {
         $this->resultPageFactory = $resultPageFactory;
         parent::__construct($context);
     }
@@ -366,7 +366,7 @@ function createControllerClassTemplate($class, $extends=false, $implements=false
     $name  = array_pop($parts);
 
     $template = '<' . '?' . 'php' . "\n" .
-    'namespace ' . implode('\\',$parts) . ";\n" .
+    'namespace ' . implode('\\',$parts) . ";\n\n" .
     "class $name";
     if($extends)
     {

--- a/modules/pulsestorm/magento2/cli/generate/crud/model/module.php
+++ b/modules/pulsestorm/magento2/cli/generate/crud/model/module.php
@@ -41,8 +41,10 @@ function getModelClassNameFromModuleInfo($moduleInfo, $modelName)
 
 function templateUpgradeDataFunction()
 {
-    return "\n" . '    public function upgrade(\Magento\Framework\Setup\ModuleDataSetupInterface $setup, \Magento\Framework\Setup\ModuleContextInterface $context)
-    {
+    return "\n" . '    public function upgrade(
+        \Magento\Framework\Setup\ModuleDataSetupInterface $setup,
+        \Magento\Framework\Setup\ModuleContextInterface $context
+    ) {
         //install data here
     }' . "\n";
 
@@ -50,16 +52,20 @@ function templateUpgradeDataFunction()
 
 function templateInstallDataFunction()
 {
-    return "\n" . '    public function install(\Magento\Framework\Setup\ModuleDataSetupInterface $setup, \Magento\Framework\Setup\ModuleContextInterface $context)
-    {
+    return "\n" . '    public function install(
+        \Magento\Framework\Setup\ModuleDataSetupInterface $setup,
+        \Magento\Framework\Setup\ModuleContextInterface $context
+    ) {
         //install data here
     }' . "\n";
 }
 
 function templateUpgradeFunction()
 {
-    return "\n" . '    public function upgrade(\Magento\Framework\Setup\SchemaSetupInterface $setup, \Magento\Framework\Setup\ModuleContextInterface $context)
-    {
+    return "\n" . '    public function upgrade(
+        \Magento\Framework\Setup\SchemaSetupInterface $setup,
+        \Magento\Framework\Setup\ModuleContextInterface $context
+    ) {
         $installer = $setup;
         $installer->startSetup();
         //START: install stuff
@@ -71,12 +77,12 @@ function templateUpgradeFunction()
 
 function templateInstallFunction()
 {
-    return "\n" . '    public function install(\Magento\Framework\Setup\SchemaSetupInterface $setup, \Magento\Framework\Setup\ModuleContextInterface $context)
-    {
+    return "\n" . '    public function install(
+        \Magento\Framework\Setup\SchemaSetupInterface $setup,
+        \Magento\Framework\Setup\ModuleContextInterface $context
+    ) {
         $installer = $setup;
         $installer->startSetup();
-        //START: install stuff
-        //END:   install stuff
         $installer->endSetup();
     }' . "\n";
 }
@@ -84,7 +90,7 @@ function templateInstallFunction()
 function templateConstruct($init1=false, $init2=false)
 {
     $params = array_filter([$init1, $init2]);
-    $params = "'" . implode("','",$params) . "'";
+    $params = "'" . implode("', '",$params) . "'";
     
     return "\n" . '    protected function _construct()' . "\n" .
     '    {' . "\n" .
@@ -112,8 +118,7 @@ function templateRepositoryInterfaceUse($longModelInterfaceName)
     return "
 use {$longModelInterfaceName};
 use Magento\Framework\Api\SortOrder;
-use Magento\Framework\Api\SearchCriteriaInterface;
-";
+use Magento\Framework\Api\SearchCriteriaInterface;";
 }
 
 function templateComplexInterface($useContents, $methodContents, $interfaceContents)
@@ -125,7 +130,7 @@ function templateComplexInterface($useContents, $methodContents, $interfaceConte
 
     $interfaceContents = preg_replace(
         '%\{\s*\}%six',
-        '{' . rtrim($methodContents) . "\n" . '}' . "\n",
+        '{' . rtrim($methodContents) . "\n" . '}',
         $interfaceContents
     );        
     
@@ -184,7 +189,7 @@ function templateRepositoryFunctions($modelName)
         '.$modelNameFactory.' $objectFactory,
         ObjectResourceModel $objectResourceModel,
         CollectionFactory $collectionFactory,
-        SearchResultsInterfaceFactory $searchResultsFactory       
+        SearchResultsInterfaceFactory $searchResultsFactory
     ) {
         $this->objectFactory        = $objectFactory;
         $this->objectResourceModel  = $objectResourceModel;
@@ -196,7 +201,7 @@ function templateRepositoryFunctions($modelName)
     {
         try {
             $this->objectResourceModel->save($object);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             throw new CouldNotSaveException(__($e->getMessage()));
         }
         return $object;
@@ -209,8 +214,8 @@ function templateRepositoryFunctions($modelName)
         if (!$object->getId()) {
             throw new NoSuchEntityException(__(\'Object with id "%1" does not exist.\', $id));
         }
-        return $object;        
-    }       
+        return $object;
+    }
 
     public function delete('.$modelInterface.' $object)
     {
@@ -219,18 +224,18 @@ function templateRepositoryFunctions($modelName)
         } catch (\Exception $exception) {
             throw new CouldNotDeleteException(__($exception->getMessage()));
         }
-        return true;    
-    }    
+        return true;
+    }
 
     public function deleteById($id)
     {
         return $this->delete($this->getById($id));
-    }    
+    }
 
     public function getList(SearchCriteriaInterface $criteria)
     {
         $searchResults = $this->searchResultsFactory->create();
-        $searchResults->setSearchCriteria($criteria);  
+        $searchResults->setSearchCriteria($criteria);
         $collection = $this->collectionFactory->create();
         foreach ($criteria->getFilterGroups() as $filterGroup) {
             $fields = [];
@@ -243,7 +248,7 @@ function templateRepositoryFunctions($modelName)
             if ($fields) {
                 $collection->addFieldToFilter($fields, $conditions);
             }
-        }  
+        }
         $searchResults->setTotalCount($collection->getSize());
         $sortOrders = $criteria->getSortOrders();
         if ($sortOrders) {
@@ -257,13 +262,13 @@ function templateRepositoryFunctions($modelName)
         }
         $collection->setCurPage($criteria->getCurrentPage());
         $collection->setPageSize($criteria->getPageSize());
-        $objects = [];                                     
+        $objects = [];
         foreach ($collection as $objectModel) {
             $objects[] = $objectModel;
         }
         $searchResults->setItems($objects);
-        return $searchResults;        
-    }';    
+        return $searchResults;
+    }' . "\n";
 }
 
 function createRepository($moduleInfo, $modelName)
@@ -363,7 +368,7 @@ function createModelClass($moduleInfo, $modelName)
     $cache_tag           = strToLower($moduleInfo->name . '_' . $modelName);
     $class_model         = getModelClassNameFromModuleInfo($moduleInfo, $modelName);
     $class_resource      = getResourceModelClassNameFromModuleInfo($moduleInfo, $modelName);
-    $implements          = getImplementsModelInterfaceName($moduleInfo, $modelName) . ', \Magento\Framework\DataObject\IdentityInterface';
+    $implements          = getImplementsModelInterfaceName($moduleInfo, $modelName) . ",\n    \Magento\Framework\DataObject\IdentityInterface";
     $template            = createClassTemplate($class_model, BASE_MODEL_CLASS, $implements);    
     $construct           = templateConstruct($class_resource);
 
@@ -468,7 +473,7 @@ function prependInstallerCodeBeforeEndSetup($moduleInfo, $modelName, $path)
     $contents     = str_replace($end_setup, 
         "\n        //START table setup\n" .
         $install_code .
-        "\n        //END   table setup\n" .
+        "\n        //END   table setup\n        " .
         $end_setup, $contents);
     return $contents;
 }

--- a/modules/pulsestorm/magento2/cli/generate/view/module.php
+++ b/modules/pulsestorm/magento2/cli/generate/view/module.php
@@ -66,7 +66,7 @@ function createBlockClass($module_info, $block_name, $area='frontname')
         $baseClass = '\Magento\Backend\Block\Template';
     }
     $contents = createClassTemplate($class_name, $baseClass);
-    $contents = str_replace('<$body$>', "\n".'    function _prepareLayout(){}'."\n", $contents);
+    $contents = str_replace('<$body$>', "\n", $contents);
     createClassFile($class_name, $contents);
     return $class_name;
 }

--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
@@ -36,13 +36,13 @@ function getPersistKeyFromModelClassName($modelClass)
 function createControllerClassBodyForIndexRedirect($module_info, $modelClass, $aclRule)
 {
     return '
-    const ADMIN_RESOURCE = \''.$aclRule.'\';  
+    const ADMIN_RESOURCE = \''.$aclRule.'\';
     public function execute()
     {
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath(\'*/index/index\');
         return $resultRedirect;
-    }     
+    }
 ';
 }
 
@@ -50,8 +50,8 @@ function createControllerClassBodyForDelete($module_info, $modelClass, $aclRule)
 {    
     $dbID           = createDbIdFromModuleInfoAndModelShortName($module_info, getModelShortName($modelClass));
     $repositoryName = '\\' . getModelRepositoryName($modelClass);
-    return '  
-    const ADMIN_RESOURCE = \''.$aclRule.'\';
+    return "\n" .
+    '    const ADMIN_RESOURCE = \''.$aclRule.'\';
     
     /**
      * @var ' . $repositoryName . '
@@ -97,9 +97,7 @@ function createControllerClassBodyForDelete($module_info, $modelClass, $aclRule)
         $this->messageManager->addError(__(\'We can not find an object to delete.\'));
         // go to grid
         return $resultRedirect->setPath(\'*/*/\');
-        
-    }    
-    
+    }
 ';    
 }
 
@@ -189,27 +187,27 @@ function createControllerClassBodyForSave($module_info, $modelClass, $aclRule)
             return $resultRedirect->setPath(\'*/*/edit\', [\''.$dbID.'\' => $this->getRequest()->getParam(\''.$dbID.'\')]);
         }
         return $resultRedirect->setPath(\'*/*/\');
-    }    
+    }
 ';
 }
 
 function createControllerClassBody($module_info, $aclRule)
 {
     return '
-    const ADMIN_RESOURCE = \''.$aclRule.'\';       
+    const ADMIN_RESOURCE = \''.$aclRule.'\';
     protected $resultPageFactory;
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory)
-    {
-        $this->resultPageFactory = $resultPageFactory;        
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+    ) {
+        $this->resultPageFactory = $resultPageFactory;
         parent::__construct($context);
     }
     
     public function execute()
     {
-        return $this->resultPageFactory->create();  
-    }    
+        return $this->resultPageFactory->create();
+    }
 ';
 }
 
@@ -499,28 +497,28 @@ function generateGenericButtonClassAndReturnName($prefix, $dbID, $aclRule)
     public function __construct(
         \Magento\Backend\Block\Widget\Context $context
     ) {
-        $this->context = $context;    
+        $this->context = $context;
     }
     
     public function getBackUrl()
     {
         return $this->getUrl(\'*/*/\');
-    }    
+    }
     
     public function getDeleteUrl()
     {
         return $this->getUrl(\'*/*/delete\', [\'object_id\' => $this->getObjectId()]);
-    }   
+    }
     
     public function getUrl($route = \'\', $params = [])
     {
         return $this->context->getUrlBuilder()->getUrl($route, $params);
-    }    
+    }
     
     public function getObjectId()
     {
         return $this->context->getRequest()->getParam(\''.$dbID.'\');
-    }     
+    }
 ';    
     $genericButtonClassContents = str_replace('<$body$>',$genericContents, $genericButtonClassContents);    
     createClassFile($genericButtonClassName,$genericButtonClassContents);                   
@@ -542,7 +540,7 @@ function getAllButtonDataStrings()
             \'label\' => __(\'Back\'),
             \'on_click\' => sprintf("location.href = \'%s\';", $this->getBackUrl()),
             \'class\' => \'back\',
-            \'sort_order\' => 10    
+            \'sort_order\' => 10
         ]',
         'delete'=> '[
                 \'label\' => __(\'Delete Object\'),
@@ -597,10 +595,11 @@ function createButtonClassContents($buttonName)
     $extra = '';
     if($buttonName === 'delete')
     {
-        $extra = 'if(!$this->getObjectId()) { return []; }';
+        $extra = 'if (!$this->getObjectId()) {
+            return [];
+        }';
     }
-    $contents = '     
-    public function getButtonData()
+    $contents = "\n". '    public function getButtonData()
     {
         '.$extra.'
         return '. $buttonData .';
@@ -616,7 +615,7 @@ function generateButtonClassAndReturnName($modelClass, $buttonName)
     
     $contents = createClassTemplateWithUse($buttonClassName, 'GenericButton', 
         'ButtonProviderInterface');
-    $contents   = str_replace('<$use$>','use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;',$contents);
+    $contents   = str_replace('<$use$>',"\n" . 'use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;',$contents);
     $contents   = str_replace('<$body$>',createButtonClassContents($buttonName),$contents);
     createClassFile($buttonClassName,$contents);            
     

--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/grid/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/grid/module.php
@@ -248,21 +248,18 @@ function generatePageActionClass($moduleInfo, $gridId, $idColumn, $collection)
             foreach ($dataSource["data"]["items"] as & $item) {
                 $name = $this->getData("name");
                 $id = "X";
-                if(isset($item["'.$idColumn.'"]))
-                {
+                if (isset($item["'.$idColumn.'"])) {
                     $id = $item["'.$idColumn.'"];
                 }
                 $item[$name]["view"] = [
-                    "href"=>$this->getContext()->getUrl(
-                        "'.$editUrl.'",["'.$idColumn.'"=>$id]),
+                    "href"=>$this->getContext()->getUrl("'.$editUrl.'", ["'.$idColumn.'"=>$id]),
                     "label"=>__("Edit")
                 ];
             }
         }
 
         return $dataSource;
-    }    
-    ' . "\n";            
+    }' . "\n";
     $contents = createClassTemplateWithUse($pageActionsClassName, '\Magento\Ui\Component\Listing\Columns\Column');            
     $contents = str_replace('<$use$>','',$contents);
     $contents = str_replace('<$body$>', $prepareDataSource, $contents);
@@ -276,8 +273,7 @@ function generateDataProviderClass($moduleInfo, $gridId, $collectionFactory)
 {
     $providerClass      = generateProdiverClassFromGridIdAndModuleInfo($gridId, $moduleInfo);    
     $collectionFactory  = '\\' . trim($collectionFactory, '\\');
-    $constructor = '    
-    public function __construct(
+    $constructor = "\n" . '    public function __construct(
         $name,
         $primaryFieldName,
         $requestFieldName,

--- a/modules/pulsestorm/pestle/library/module.php
+++ b/modules/pulsestorm/pestle/library/module.php
@@ -42,7 +42,7 @@ function getNewClassDeclaration($class, $extends, $include_start_bracket=true)
     $parts = [];
     $parts[] = 'namespace';
     $parts[] = $class['namespace'] . ';';
-    $parts[] = "\n";
+    $parts[] = "\n\n";
 
     if($extends['class'])
     {

--- a/tests/LibraryTest.php
+++ b/tests/LibraryTest.php
@@ -23,6 +23,7 @@ class LibraryTest extends PestleBaseTest
     {
         $fixture = '<' . '?php
 namespace ;
+
 class Foo
 {<$body$>}' . "\n";  
  


### PR DESCRIPTION
Hello,

I'm working on resolving issue #273.

I have added the composer dependancy `squizlabs/php_codesniffer` and use the following command to check the PSR2 compliance as Vinai suggested:

```
vendor/bin/phpcs --standard=psr2 <path_to_module>
```

Two issues remain:

- Method name "_construct" should not be prefixed with an underscore to indicate visibility": this issue is caused by extending Magento classes -- should we ignore it?
- The most important IMO, the blank lines after `namespace` and `use` statements. Sometimes it's ok, sometimes there is no blank lines and sometimes there are two blank lines... I need some help on this one, I tried several things and when I fix something, I break something else.

Thanks!