### PR TITLE
Issue #435 - Unable to find the wrapper "phar"

### DIFF
--- a/modules/pulsestorm/magento2/cli/class_list/module.php
+++ b/modules/pulsestorm/magento2/cli/class_list/module.php
@@ -138,6 +138,10 @@ function pestle_cli($argv)
         // Magento's autoloaders are loaded here
         require getBaseMagentoDir() . '/app/bootstrap.php';
 
+        if (!in_array('phar', \stream_get_wrappers())) {
+            \stream_wrapper_restore('phar');
+        }
+
         registerAutoloaders($pestlesLoaders);
         /*
          * TODO: wrap this logic in an application container


### PR DESCRIPTION
Using the same fix as n98-magerun2 which work perfectly on 2.2.8. I did not test on other versions of Magento

https://github.com/netz98/n98-magerun2/commit/59e0aec6097e6e8bed217aa1343d6906bb5fb92c#diff-e42fe36d3628b1f8e91a653d64c7ba6d