### PR TITLE
Removeing Third Party Source

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,6 @@ nav:
 
     - Pestle Modules:
         - Generate a Module: pestle-generate.md
-        - Third Party Modules: pestle-third-party.md
         - Helpful Library Functions: pestle-library.md
     - Development:
         - Introduction: dev-internals-introduction.md


### PR DESCRIPTION
We ended up covering this (and naming the configuration "module source") in the [Generate a Module](https://pestle.readthedocs.io/en/latest/pestle-generate/) documentation. No need for it. 