### PR TITLE
fixed an issue in layout xml files names

### DIFF
--- a/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
+++ b/modules/pulsestorm/magento2/cli/magento2/generate/ui/form/module.php
@@ -453,7 +453,7 @@ function createLayoutXmlFiles($module_info, $modelClass)
 
     $prefixFilename = implode('_', [
         strToLower($module_info->name),
-        createShortPluralModelName($modelClass),
+        // createShortPluralModelName($modelClass),
         strToLower(getModelShortName($modelClass))
         // 'index'
     ]);;


### PR DESCRIPTION
this issue happens when creating a ui form for a newly created model, using 
`php pestle.phar magento2:generate:ui:form`